### PR TITLE
add manual scene threshold flag for `scene_detection`

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,9 +26,53 @@ def get_face_cascade():
         _face_cascade = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
     return _face_cascade
 
-def analyze_scene_content(video_path, scene_start_time, scene_end_time):
+def _iou(box_a, box_b):
+    """Intersection-over-union for two [x1, y1, x2, y2] boxes."""
+    ax1, ay1, ax2, ay2 = box_a
+    bx1, by1, bx2, by2 = box_b
+    ix1, iy1 = max(ax1, bx1), max(ay1, by1)
+    ix2, iy2 = min(ax2, bx2), min(ay2, by2)
+    iw, ih = max(0, ix2 - ix1), max(0, iy2 - iy1)
+    inter = iw * ih
+    if inter == 0:
+        return 0.0
+    area_a = max(0, ax2 - ax1) * max(0, ay2 - ay1)
+    area_b = max(0, bx2 - bx1) * max(0, by2 - by1)
+    union = area_a + area_b - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _detect_people_in_frame(frame):
+    """Run YOLO + face cascade on a single frame, return a list of detections."""
+    import cv2
+    results = get_yolo_model()([frame], verbose=False)
+    detected = []
+    for result in results:
+        for box in result.boxes:
+            if box.cls[0] != 0:
+                continue
+            x1, y1, x2, y2 = [int(i) for i in box.xyxy[0]]
+            person_box = [x1, y1, x2, y2]
+            person_roi_gray = cv2.cvtColor(frame[y1:y2, x1:x2], cv2.COLOR_BGR2GRAY)
+            faces = get_face_cascade().detectMultiScale(
+                person_roi_gray, scaleFactor=1.1, minNeighbors=5, minSize=(30, 30))
+            face_box = None
+            if len(faces) > 0:
+                fx, fy, fw, fh = faces[0]
+                face_box = [x1 + fx, y1 + fy, x1 + fx + fw, y1 + fy + fh]
+            detected.append({'person_box': person_box, 'face_box': face_box})
+    return detected
+
+
+def analyze_scene_content(video_path, scene_start_time, scene_end_time, samples=1):
     """
-    Analyzes the middle frame of a scene to detect people and faces.
+    Analyzes one or more frames inside a scene to detect people and faces.
+
+    Args:
+        samples: Number of evenly-spaced frames to sample from the scene.
+                 1 (default) = only the middle frame (legacy behavior).
+                 Higher values catch people who appear briefly or were missed
+                 in the middle frame, at the cost of more YOLO inference.
     """
     import cv2
     cap = cv2.VideoCapture(video_path)
@@ -38,41 +82,48 @@ def analyze_scene_content(video_path, scene_start_time, scene_end_time):
 
     start_frame = scene_start_time.get_frames()
     end_frame = scene_end_time.get_frames()
-    middle_frame_number = int(start_frame + (end_frame - start_frame) / 2)
+    span = max(1, end_frame - start_frame)
 
-    cap.set(cv2.CAP_PROP_POS_FRAMES, middle_frame_number)
+    samples = max(1, samples)
+    if samples == 1:
+        frame_numbers = [int(start_frame + span / 2)]
+    else:
+        # Evenly spaced inside the scene, avoiding the exact boundaries
+        frame_numbers = [
+            int(start_frame + span * (i + 1) / (samples + 1))
+            for i in range(samples)
+        ]
 
-    ret, frame = cap.read()
-    if not ret:
-        cap.release()
+    all_detections = []
+    for fn in frame_numbers:
+        cap.set(cv2.CAP_PROP_POS_FRAMES, fn)
+        ret, frame = cap.read()
+        if not ret:
+            continue
+        all_detections.extend(_detect_people_in_frame(frame))
+    cap.release()
+
+    if not all_detections:
         return []
 
-    results = get_yolo_model()([frame], verbose=False)
-
-    detected_objects = []
-
-    for result in results:
-        boxes = result.boxes
-        for box in boxes:
-            if box.cls[0] == 0:
-                x1, y1, x2, y2 = [int(i) for i in box.xyxy[0]]
-                person_box = [x1, y1, x2, y2]
-
-                person_roi_gray = cv2.cvtColor(frame[y1:y2, x1:x2], cv2.COLOR_BGR2GRAY)
-                faces = get_face_cascade().detectMultiScale(person_roi_gray, scaleFactor=1.1, minNeighbors=5, minSize=(30, 30))
-
-                face_box = None
-                if len(faces) > 0:
-                    fx, fy, fw, fh = faces[0]
-                    face_box = [x1 + fx, y1 + fy, x1 + fx + fw, y1 + fy + fh]
-
-                detected_objects.append({'person_box': person_box, 'face_box': face_box})
-
-    cap.release()
-    return detected_objects
+    # Merge detections across sampled frames: same person ≈ overlapping box.
+    merged = []
+    for det in all_detections:
+        matched = False
+        for m in merged:
+            if _iou(det['person_box'], m['person_box']) > 0.5:
+                # Keep a face box if either detection has one
+                if m['face_box'] is None and det['face_box'] is not None:
+                    m['face_box'] = det['face_box']
+                matched = True
+                break
+        if not matched:
+            merged.append(dict(det))
+    return merged
 
 
-def detect_scenes(video_path, downscale=0, frame_skip=0):
+def detect_scenes(video_path, downscale=0, frame_skip=0,
+                  detector='content', threshold=27.0, min_scene_len=15):
     """Detect scene boundaries.
 
     Args:
@@ -81,12 +132,34 @@ def detect_scenes(video_path, downscale=0, frame_skip=0):
                    resolution).  Higher values are faster but may miss subtle cuts.
         frame_skip: Number of frames to skip between each processed frame.
                     0 = process every frame (default, most accurate).
+        detector: 'content' (default, fixed threshold) or 'adaptive'
+                  (better for camera motion / gradual lighting changes).
+        threshold: Cut sensitivity. For 'content', PySceneDetect default is 27;
+                   lower values (12–20) catch subtler cuts (talk shows, dialogue
+                   with similar lighting). For 'adaptive', default is 3.0.
+        min_scene_len: Minimum scene length in frames (default 15). Lower this
+                   to catch very quick cuts (e.g. montages).
     """
     from scenedetect import VideoManager, SceneManager
     from scenedetect.detectors import ContentDetector
     video_manager = VideoManager([video_path])
     scene_manager = SceneManager()
-    scene_manager.add_detector(ContentDetector())
+
+    if detector == 'adaptive':
+        try:
+            from scenedetect.detectors import AdaptiveDetector
+            scene_manager.add_detector(
+                AdaptiveDetector(adaptive_threshold=threshold,
+                                 min_scene_len=min_scene_len))
+        except ImportError:
+            print("  ⚠️  AdaptiveDetector unavailable in this PySceneDetect version, "
+                  "falling back to ContentDetector.")
+            scene_manager.add_detector(
+                ContentDetector(threshold=threshold, min_scene_len=min_scene_len))
+    else:
+        scene_manager.add_detector(
+            ContentDetector(threshold=threshold, min_scene_len=min_scene_len))
+
     if downscale > 0:
         video_manager.set_downscale_factor(downscale)
     else:
@@ -406,6 +479,23 @@ if __name__ == '__main__':
     parser.add_argument('--downscale', type=int, default=0,
                         help="Downscale factor for scene detection (default: 0 = auto). "
                              "Higher values (2-4) are faster but may miss subtle scene changes.")
+    parser.add_argument('--scene-detector', type=str, default='content',
+                        choices=['content', 'adaptive'],
+                        help="Scene-detection algorithm. 'content' (default) uses a fixed "
+                             "threshold; 'adaptive' adapts to camera motion / gradual lighting "
+                             "changes and usually catches more cuts in dynamic footage.")
+    parser.add_argument('--scene-threshold', type=float, default=None,
+                        help="Cut sensitivity. For --scene-detector content, default is 27 "
+                             "(PySceneDetect default); LOWER values (e.g. 15-20) detect more "
+                             "subtle cuts (dialogue, talk shows, similar lighting). "
+                             "For --scene-detector adaptive, default is 3.0.")
+    parser.add_argument('--min-scene-len', type=int, default=15,
+                        help="Minimum scene length in frames (default 15). Lower this to "
+                             "catch very fast cuts (montages, action edits).")
+    parser.add_argument('--analysis-samples', type=int, default=3,
+                        help="Number of frames to sample per scene for person detection "
+                             "(default 3). Higher = more reliable people detection at the "
+                             "cost of more YOLO inference. 1 = legacy middle-frame-only.")
     parser.add_argument('--encoder', type=str, default='auto',
                         help="Video encoder: 'auto' (libx264, default), 'hw' (auto-detect hardware encoder), "
                              "or a specific encoder name like 'h264_videotoolbox' or 'h264_nvenc'.")
@@ -496,7 +586,21 @@ if __name__ == '__main__':
 
     print("🎬 Step 1: Detecting scenes...")
     step_start_time = time.time()
-    scenes, _ = detect_scenes(input_video, downscale=args.downscale, frame_skip=args.frame_skip)
+    # Apply detector-specific default threshold if user did not set one
+    if args.scene_threshold is not None:
+        scene_threshold = args.scene_threshold
+    else:
+        scene_threshold = 3.0 if args.scene_detector == 'adaptive' else 27.0
+    print(f"   Detector: {args.scene_detector} | threshold: {scene_threshold} | "
+          f"min-scene-len: {args.min_scene_len}")
+    scenes, _ = detect_scenes(
+        input_video,
+        downscale=args.downscale,
+        frame_skip=args.frame_skip,
+        detector=args.scene_detector,
+        threshold=scene_threshold,
+        min_scene_len=args.min_scene_len,
+    )
     step_end_time = time.time()
     
     if not scenes:
@@ -523,7 +627,8 @@ if __name__ == '__main__':
 
     scenes_analysis = []
     for i, (start_time, end_time) in enumerate(tqdm(scenes, desc="Analyzing Scenes")):
-        analysis = analyze_scene_content(input_video, start_time, end_time)
+        analysis = analyze_scene_content(input_video, start_time, end_time,
+                                         samples=args.analysis_samples)
         strategy, target_box = decide_cropping_strategy(analysis, original_height)
         scenes_analysis.append({
             'start_frame': start_time.get_frames(),


### PR DESCRIPTION
this might need some clean-up since this was done on the first prompt given to opus 4.7 but the working solution is here.

Would resolve the issue of not detecting scenes despite multiple people existing throughout the provided video by allowing the ability to manual set the threshold. default value wasn't enough for my case.

fixes https://github.com/kamilstanuch/Autocrop-vertical/issues/7